### PR TITLE
Bump dependencies (combine 4 Dependabot PRs)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,31 @@
 {
     "name": "lc_notebook_diff",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lc_notebook_diff",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@emotion/react": "^11.11.3",
                 "@emotion/styled": "^11.11.0",
+                "@fortawesome/free-solid-svg-icons": "^6.5.1",
                 "@jupyterlab/application": "^4.0.0",
                 "@mui/icons-material": "^5.15.2",
                 "@mui/material": "^5.15.2",
-                "lc_notebook_diff_components": "file:./components"
+                "codemirror": "^5.65.14",
+                "diff-match-patch": "^1.0.5",
+                "jquery": "^3.7.1"
             },
             "devDependencies": {
                 "@jupyterlab/builder": "^4.0.0",
                 "@jupyterlab/testutils": "^4.0.0",
+                "@types/codemirror": "^5.60.8",
+                "@types/diff-match-patch": "^1.0.32",
                 "@types/jest": "^29.2.0",
+                "@types/jquery": "^3.5.29",
                 "@types/json-schema": "^7.0.11",
                 "@types/react": "^18.0.26",
                 "@types/react-addons-linked-state-mixin": "^0.14.22",
@@ -40,30 +46,18 @@
                 "stylelint-config-standard": "^34.0.0",
                 "stylelint-csstree-validator": "^3.0.0",
                 "stylelint-prettier": "^4.0.0",
-                "typescript": "~5.0.2",
+                "typescript": "^5.0.2",
                 "yjs": "^13.5.0"
             }
         },
         "components": {
             "name": "lc_notebook_diff_components",
             "version": "0.1.0",
+            "extraneous": true,
             "license": "BSD-3-Clause",
             "devDependencies": {
                 "@types/jquery": "^3.5.29",
                 "typescript": "^5.3.3"
-            }
-        },
-        "components/node_modules/typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "dev": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -2416,10 +2410,31 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
             "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
         },
+        "node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+            "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/@fortawesome/fontawesome-free": {
             "version": "5.15.4",
             "hasInstallScript": true,
             "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-solid-svg-icons": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+            "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+            "license": "(CC-BY-4.0 AND MIT)",
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.7.2"
+            },
             "engines": {
                 "node": ">=6"
             }
@@ -4280,6 +4295,23 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/codemirror": {
+            "version": "5.60.17",
+            "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.17.tgz",
+            "integrity": "sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/tern": "*"
+            }
+        },
+        "node_modules/@types/diff-match-patch": {
+            "version": "1.0.36",
+            "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+            "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/eslint": {
             "version": "8.56.0",
             "dev": true,
@@ -4445,6 +4477,16 @@
             "version": "2.0.3",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/tern": {
+            "version": "0.23.9",
+            "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+            "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*"
+            }
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
@@ -5533,6 +5575,12 @@
                 "node": ">= 0.12.0"
             }
         },
+        "node_modules/codemirror": {
+            "version": "5.65.20",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.20.tgz",
+            "integrity": "sha512-i5dLDDxwkFCbhjvL2pNjShsojoL3XHyDwsGv1jqETUoW+lzpBKKqNTUWgQwVAOa0tUm4BwekT455ujafi8payA==",
+            "license": "MIT"
+        },
         "node_modules/collect-v8-coverage": {
             "version": "1.0.2",
             "dev": true,
@@ -5930,6 +5978,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/diff-match-patch": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+            "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+            "license": "Apache-2.0"
         },
         "node_modules/diff-sequences": {
             "version": "29.6.3",
@@ -8326,6 +8380,12 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/jquery": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+            "license": "MIT"
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "license": "MIT"
@@ -8556,10 +8616,6 @@
             "version": "0.29.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/lc_notebook_diff_components": {
-            "resolved": "components",
-            "link": true
         },
         "node_modules/leven": {
             "version": "3.1.0",
@@ -9011,7 +9067,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
+            "version": "3.3.11",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+            "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
             "funding": [
                 {
                     "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,31 @@
 {
     "name": "lc_notebook_diff",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lc_notebook_diff",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@emotion/react": "^11.11.3",
                 "@emotion/styled": "^11.11.0",
+                "@fortawesome/free-solid-svg-icons": "^6.5.1",
                 "@jupyterlab/application": "^4.0.0",
                 "@mui/icons-material": "^5.15.2",
                 "@mui/material": "^5.15.2",
-                "lc_notebook_diff_components": "file:./components"
+                "codemirror": "^5.65.14",
+                "diff-match-patch": "^1.0.5",
+                "jquery": "^3.7.1"
             },
             "devDependencies": {
                 "@jupyterlab/builder": "^4.0.0",
                 "@jupyterlab/testutils": "^4.0.0",
+                "@types/codemirror": "^5.60.8",
+                "@types/diff-match-patch": "^1.0.32",
                 "@types/jest": "^29.2.0",
+                "@types/jquery": "^3.5.29",
                 "@types/json-schema": "^7.0.11",
                 "@types/react": "^18.0.26",
                 "@types/react-addons-linked-state-mixin": "^0.14.22",
@@ -40,30 +46,18 @@
                 "stylelint-config-standard": "^34.0.0",
                 "stylelint-csstree-validator": "^3.0.0",
                 "stylelint-prettier": "^4.0.0",
-                "typescript": "~5.0.2",
+                "typescript": "^5.0.2",
                 "yjs": "^13.5.0"
             }
         },
         "components": {
             "name": "lc_notebook_diff_components",
             "version": "0.1.0",
+            "extraneous": true,
             "license": "BSD-3-Clause",
             "devDependencies": {
                 "@types/jquery": "^3.5.29",
                 "typescript": "^5.3.3"
-            }
-        },
-        "components/node_modules/typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "dev": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -2416,10 +2410,31 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
             "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
         },
+        "node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+            "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/@fortawesome/fontawesome-free": {
             "version": "5.15.4",
             "hasInstallScript": true,
             "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-solid-svg-icons": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+            "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+            "license": "(CC-BY-4.0 AND MIT)",
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.7.2"
+            },
             "engines": {
                 "node": ">=6"
             }
@@ -4280,6 +4295,23 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/codemirror": {
+            "version": "5.60.17",
+            "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.17.tgz",
+            "integrity": "sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/tern": "*"
+            }
+        },
+        "node_modules/@types/diff-match-patch": {
+            "version": "1.0.36",
+            "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+            "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/eslint": {
             "version": "8.56.0",
             "dev": true,
@@ -4445,6 +4477,16 @@
             "version": "2.0.3",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/tern": {
+            "version": "0.23.9",
+            "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+            "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*"
+            }
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
@@ -5533,6 +5575,12 @@
                 "node": ">= 0.12.0"
             }
         },
+        "node_modules/codemirror": {
+            "version": "5.65.20",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.20.tgz",
+            "integrity": "sha512-i5dLDDxwkFCbhjvL2pNjShsojoL3XHyDwsGv1jqETUoW+lzpBKKqNTUWgQwVAOa0tUm4BwekT455ujafi8payA==",
+            "license": "MIT"
+        },
         "node_modules/collect-v8-coverage": {
             "version": "1.0.2",
             "dev": true,
@@ -5930,6 +5978,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/diff-match-patch": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+            "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+            "license": "Apache-2.0"
         },
         "node_modules/diff-sequences": {
             "version": "29.6.3",
@@ -8326,6 +8380,12 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/jquery": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+            "license": "MIT"
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "license": "MIT"
@@ -8556,10 +8616,6 @@
             "version": "0.29.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/lc_notebook_diff_components": {
-            "resolved": "components",
-            "link": true
         },
         "node_modules/leven": {
             "version": "3.1.0",
@@ -11930,7 +11986,9 @@
             "license": "ISC"
         },
         "node_modules/ws": {
-            "version": "8.16.0",
+            "version": "8.18.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+            "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,31 @@
 {
     "name": "lc_notebook_diff",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lc_notebook_diff",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@emotion/react": "^11.11.3",
                 "@emotion/styled": "^11.11.0",
+                "@fortawesome/free-solid-svg-icons": "^6.5.1",
                 "@jupyterlab/application": "^4.0.0",
                 "@mui/icons-material": "^5.15.2",
                 "@mui/material": "^5.15.2",
-                "lc_notebook_diff_components": "file:./components"
+                "codemirror": "^5.65.14",
+                "diff-match-patch": "^1.0.5",
+                "jquery": "^3.7.1"
             },
             "devDependencies": {
                 "@jupyterlab/builder": "^4.0.0",
                 "@jupyterlab/testutils": "^4.0.0",
+                "@types/codemirror": "^5.60.8",
+                "@types/diff-match-patch": "^1.0.32",
                 "@types/jest": "^29.2.0",
+                "@types/jquery": "^3.5.29",
                 "@types/json-schema": "^7.0.11",
                 "@types/react": "^18.0.26",
                 "@types/react-addons-linked-state-mixin": "^0.14.22",
@@ -40,30 +46,18 @@
                 "stylelint-config-standard": "^34.0.0",
                 "stylelint-csstree-validator": "^3.0.0",
                 "stylelint-prettier": "^4.0.0",
-                "typescript": "~5.0.2",
+                "typescript": "^5.0.2",
                 "yjs": "^13.5.0"
             }
         },
         "components": {
             "name": "lc_notebook_diff_components",
             "version": "0.1.0",
+            "extraneous": true,
             "license": "BSD-3-Clause",
             "devDependencies": {
                 "@types/jquery": "^3.5.29",
                 "typescript": "^5.3.3"
-            }
-        },
-        "components/node_modules/typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "dev": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -1757,11 +1751,10 @@
             "license": "MIT"
         },
         "node_modules/@babel/runtime": {
-            "version": "7.23.7",
+            "version": "7.28.4",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
             "license": "MIT",
-            "dependencies": {
-                "regenerator-runtime": "^0.14.0"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -2416,10 +2409,31 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
             "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
         },
+        "node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+            "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/@fortawesome/fontawesome-free": {
             "version": "5.15.4",
             "hasInstallScript": true,
             "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-solid-svg-icons": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+            "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+            "license": "(CC-BY-4.0 AND MIT)",
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.7.2"
+            },
             "engines": {
                 "node": ">=6"
             }
@@ -4280,6 +4294,23 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/codemirror": {
+            "version": "5.60.17",
+            "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.17.tgz",
+            "integrity": "sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/tern": "*"
+            }
+        },
+        "node_modules/@types/diff-match-patch": {
+            "version": "1.0.36",
+            "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+            "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/eslint": {
             "version": "8.56.0",
             "dev": true,
@@ -4445,6 +4476,16 @@
             "version": "2.0.3",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/tern": {
+            "version": "0.23.9",
+            "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+            "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*"
+            }
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
@@ -5533,6 +5574,12 @@
                 "node": ">= 0.12.0"
             }
         },
+        "node_modules/codemirror": {
+            "version": "5.65.20",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.20.tgz",
+            "integrity": "sha512-i5dLDDxwkFCbhjvL2pNjShsojoL3XHyDwsGv1jqETUoW+lzpBKKqNTUWgQwVAOa0tUm4BwekT455ujafi8payA==",
+            "license": "MIT"
+        },
         "node_modules/collect-v8-coverage": {
             "version": "1.0.2",
             "dev": true,
@@ -5930,6 +5977,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/diff-match-patch": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+            "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+            "license": "Apache-2.0"
         },
         "node_modules/diff-sequences": {
             "version": "29.6.3",
@@ -8326,6 +8379,12 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/jquery": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+            "license": "MIT"
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "license": "MIT"
@@ -8556,10 +8615,6 @@
             "version": "0.29.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/lc_notebook_diff_components": {
-            "resolved": "components",
-            "link": true
         },
         "node_modules/leven": {
             "version": "3.1.0",
@@ -10046,10 +10101,6 @@
             "engines": {
                 "node": ">=4"
             }
-        },
-        "node_modules/regenerator-runtime": {
-            "version": "0.14.1",
-            "license": "MIT"
         },
         "node_modules/regenerator-transform": {
             "version": "0.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,25 +1,31 @@
 {
     "name": "lc_notebook_diff",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "lc_notebook_diff",
-            "version": "0.1.0",
+            "version": "0.2.0",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@emotion/react": "^11.11.3",
                 "@emotion/styled": "^11.11.0",
+                "@fortawesome/free-solid-svg-icons": "^6.5.1",
                 "@jupyterlab/application": "^4.0.0",
                 "@mui/icons-material": "^5.15.2",
                 "@mui/material": "^5.15.2",
-                "lc_notebook_diff_components": "file:./components"
+                "codemirror": "^5.65.14",
+                "diff-match-patch": "^1.0.5",
+                "jquery": "^3.7.1"
             },
             "devDependencies": {
                 "@jupyterlab/builder": "^4.0.0",
                 "@jupyterlab/testutils": "^4.0.0",
+                "@types/codemirror": "^5.60.8",
+                "@types/diff-match-patch": "^1.0.32",
                 "@types/jest": "^29.2.0",
+                "@types/jquery": "^3.5.29",
                 "@types/json-schema": "^7.0.11",
                 "@types/react": "^18.0.26",
                 "@types/react-addons-linked-state-mixin": "^0.14.22",
@@ -40,30 +46,18 @@
                 "stylelint-config-standard": "^34.0.0",
                 "stylelint-csstree-validator": "^3.0.0",
                 "stylelint-prettier": "^4.0.0",
-                "typescript": "~5.0.2",
+                "typescript": "^5.0.2",
                 "yjs": "^13.5.0"
             }
         },
         "components": {
             "name": "lc_notebook_diff_components",
             "version": "0.1.0",
+            "extraneous": true,
             "license": "BSD-3-Clause",
             "devDependencies": {
                 "@types/jquery": "^3.5.29",
                 "typescript": "^5.3.3"
-            }
-        },
-        "components/node_modules/typescript": {
-            "version": "5.3.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
-            "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-            "dev": true,
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
             }
         },
         "node_modules/@aashutoshrathi/word-wrap": {
@@ -2416,10 +2410,31 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
             "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
         },
+        "node_modules/@fortawesome/fontawesome-common-types": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.7.2.tgz",
+            "integrity": "sha512-Zs+YeHUC5fkt7Mg1l6XTniei3k4bwG/yo3iFUtZWd/pMx9g3fdvkSK9E0FOC+++phXOka78uJcYb8JaFkW52Xg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/@fortawesome/fontawesome-free": {
             "version": "5.15.4",
             "hasInstallScript": true,
             "license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/@fortawesome/free-solid-svg-icons": {
+            "version": "6.7.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.7.2.tgz",
+            "integrity": "sha512-GsBrnOzU8uj0LECDfD5zomZJIjrPhIlWU82AHwa2s40FKH+kcxQaBvBo3Z4TxyZHIyX8XTDxsyA33/Vx9eFuQA==",
+            "license": "(CC-BY-4.0 AND MIT)",
+            "dependencies": {
+                "@fortawesome/fontawesome-common-types": "6.7.2"
+            },
             "engines": {
                 "node": ">=6"
             }
@@ -4280,6 +4295,23 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/codemirror": {
+            "version": "5.60.17",
+            "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.17.tgz",
+            "integrity": "sha512-AZq2FIsUHVMlp7VSe2hTfl5w4pcUkoFkM3zVsRKsn1ca8CXRDYvnin04+HP2REkwsxemuHqvDofdlhUWNpbwfw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/tern": "*"
+            }
+        },
+        "node_modules/@types/diff-match-patch": {
+            "version": "1.0.36",
+            "resolved": "https://registry.npmjs.org/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz",
+            "integrity": "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/eslint": {
             "version": "8.56.0",
             "dev": true,
@@ -4445,6 +4477,16 @@
             "version": "2.0.3",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@types/tern": {
+            "version": "0.23.9",
+            "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+            "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*"
+            }
         },
         "node_modules/@types/tough-cookie": {
             "version": "4.0.5",
@@ -5292,11 +5334,13 @@
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -5532,6 +5576,12 @@
                 "iojs": ">= 1.0.0",
                 "node": ">= 0.12.0"
             }
+        },
+        "node_modules/codemirror": {
+            "version": "5.65.20",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.20.tgz",
+            "integrity": "sha512-i5dLDDxwkFCbhjvL2pNjShsojoL3XHyDwsGv1jqETUoW+lzpBKKqNTUWgQwVAOa0tUm4BwekT455ujafi8payA==",
+            "license": "MIT"
         },
         "node_modules/collect-v8-coverage": {
             "version": "1.0.2",
@@ -5930,6 +5980,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/diff-match-patch": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.5.tgz",
+            "integrity": "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==",
+            "license": "Apache-2.0"
         },
         "node_modules/diff-sequences": {
             "version": "29.6.3",
@@ -6735,7 +6791,9 @@
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -7511,6 +7569,8 @@
         },
         "node_modules/is-number": {
             "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -8326,6 +8386,12 @@
                 "url": "https://github.com/chalk/supports-color?sponsor=1"
             }
         },
+        "node_modules/jquery": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==",
+            "license": "MIT"
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "license": "MIT"
@@ -8556,10 +8622,6 @@
             "version": "0.29.0",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/lc_notebook_diff_components": {
-            "resolved": "components",
-            "link": true
         },
         "node_modules/leven": {
             "version": "3.1.0",
@@ -11178,6 +11240,8 @@
         },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -10195,11 +10195,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
   version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=85af82"
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
+  checksum: 4e604a9e107ce0c23b16a2f8d79d0531d4d8fe9ebbb7a8c395c66998c39892f0e0a071ef0b0d4e66420a8ec2b8d6cfd9cdb29ba24f25b37cba072e9282376df9
   languageName: node
   linkType: hard
 
@@ -10780,8 +10780,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^8.11.0":
-  version: 8.16.0
-  resolution: "ws@npm:8.16.0"
+  version: 8.18.3
+  resolution: "ws@npm:8.18.3"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -10790,7 +10790,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: feb3eecd2bae82fa8a8beef800290ce437d8b8063bdc69712725f21aef77c49cb2ff45c6e5e7fce622248f9c7abaee506bae0a9064067ffd6935460c7357321b
+  checksum: d64ef1631227bd0c5fe21b3eb3646c9c91229402fb963d12d87b49af0a1ef757277083af23a5f85742bae1e520feddfb434cb882ea59249b15673c16dc3f36e0
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1326,11 +1326,9 @@ __metadata:
   linkType: hard
 
 "@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.23.8, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.8.7":
-  version: 7.23.8
-  resolution: "@babel/runtime@npm:7.23.8"
-  dependencies:
-    regenerator-runtime: ^0.14.0
-  checksum: 0bd5543c26811153822a9f382fd39886f66825ff2a397a19008011376533747cd05c33a91f6248c0b8b0edf0448d7c167ebfba34786088f1b7eb11c65be7dfc3
+  version: 7.28.4
+  resolution: "@babel/runtime@npm:7.28.4"
+  checksum: 934b0a0460f7d06637d93fcd1a44ac49adc33518d17253b5a0b55ff4cb90a45d8fe78bf034b448911dbec7aff2a90b918697559f78d21c99ff8dbadae9565b55
   languageName: node
   linkType: hard
 
@@ -8961,13 +8959,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"regenerator-runtime@npm:^0.14.0":
-  version: 0.14.1
-  resolution: "regenerator-runtime@npm:0.14.1"
-  checksum: 9f57c93277b5585d3c83b0cf76be47b473ae8c6d9142a46ce8b0291a04bb2cf902059f0f8445dcabb3fb7378e5fe4bb4ea1e008876343d42e46d3b484534ce38
-  languageName: node
-  linkType: hard
-
 "regenerator-transform@npm:^0.15.2":
   version: 0.15.2
   resolution: "regenerator-transform@npm:0.15.2"
@@ -10195,11 +10186,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
   version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=85af82"
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
+  checksum: 4e604a9e107ce0c23b16a2f8d79d0531d4d8fe9ebbb7a8c395c66998c39892f0e0a071ef0b0d4e66420a8ec2b8d6cfd9cdb29ba24f25b37cba072e9282376df9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8181,11 +8181,11 @@ __metadata:
   linkType: hard
 
 "nanoid@npm:^3.3.7":
-  version: 3.3.7
-  resolution: "nanoid@npm:3.3.7"
+  version: 3.3.11
+  resolution: "nanoid@npm:3.3.11"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: d36c427e530713e4ac6567d488b489a36582ef89da1d6d4e3b87eded11eb10d7042a877958c6f104929809b2ab0bafa17652b076cdf84324aa75b30b722204f2
+  checksum: 3be20d8866a57a6b6d218e82549711c8352ed969f9ab3c45379da28f405363ad4c9aeb0b39e9abc101a529ca65a72ff9502b00bf74a912c4b64a9d62dfd26c29
   languageName: node
   linkType: hard
 
@@ -10195,11 +10195,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
   version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=85af82"
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
+  checksum: 4e604a9e107ce0c23b16a2f8d79d0531d4d8fe9ebbb7a8c395c66998c39892f0e0a071ef0b0d4e66420a8ec2b8d6cfd9cdb29ba24f25b37cba072e9282376df9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4601,11 +4601,11 @@ __metadata:
   linkType: hard
 
 "braces@npm:^3.0.2":
-  version: 3.0.2
-  resolution: "braces@npm:3.0.2"
+  version: 3.0.3
+  resolution: "braces@npm:3.0.3"
   dependencies:
-    fill-range: ^7.0.1
-  checksum: e2a8e769a863f3d4ee887b5fe21f63193a891c68b612ddb4b68d82d1b5f3ff9073af066c343e9867a393fe4c2555dcb33e89b937195feb9c1613d259edfcd459
+    fill-range: ^7.1.1
+  checksum: b95aa0b3bd909f6cd1720ffcf031aeaf46154dd88b4da01f9a1d3f7ea866a79eba76a6d01cbc3c422b2ee5cdc39a4f02491058d5df0d7bf6e6a162a832df1f69
   languageName: node
   linkType: hard
 
@@ -5885,12 +5885,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fill-range@npm:^7.0.1":
-  version: 7.0.1
-  resolution: "fill-range@npm:7.0.1"
+"fill-range@npm:^7.1.1":
+  version: 7.1.1
+  resolution: "fill-range@npm:7.1.1"
   dependencies:
     to-regex-range: ^5.0.1
-  checksum: cc283f4e65b504259e64fd969bcf4def4eb08d85565e906b7d36516e87819db52029a76b6363d0f02d0d532f0033c9603b9e2d943d56ee3b0d4f7ad3328ff917
+  checksum: b4abfbca3839a3d55e4ae5ec62e131e2e356bf4859ce8480c64c4876100f4df292a63e5bb1618e1d7460282ca2b305653064f01654474aa35c68000980f17798
   languageName: node
   linkType: hard
 
@@ -10195,11 +10195,11 @@ __metadata:
 
 "typescript@patch:typescript@^5.0.2#~builtin<compat/typescript>":
   version: 5.3.3
-  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=85af82"
+  resolution: "typescript@patch:typescript@npm%3A5.3.3#~builtin<compat/typescript>::version=5.3.3&hash=e012d7"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: f61375590b3162599f0f0d5b8737877ac0a7bc52761dbb585d67e7b8753a3a4c42d9a554c4cc929f591ffcf3a2b0602f65ae3ce74714fd5652623a816862b610
+  checksum: 4e604a9e107ce0c23b16a2f8d79d0531d4d8fe9ebbb7a8c395c66998c39892f0e0a071ef0b0d4e66420a8ec2b8d6cfd9cdb29ba24f25b37cba072e9282376df9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Combine remaining 4 open Dependabot PRs into a single PR for easier review and testing
- Bumped packages: ws, @babel/runtime, nanoid, braces

## Included PRs
- #26 Bump ws from 8.16.0 to 8.18.3
- #27 Bump @babel/runtime from 7.23.7 to 7.28.4
- #28 Bump nanoid from 3.3.7 to 3.3.11
- #29 Bump braces from 3.0.2 to 3.0.3