### PR TITLE
Update deprecated GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/binder-on-pr.yml
+++ b/.github/workflows/binder-on-pr.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: comment on PR with Binder link
-        uses: actions/github-script@v3
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
@@ -76,9 +76,9 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         architecture: 'x64'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,20 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Install node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
        node-version: 18
     - name: Install Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.9'
         architecture: 'x64'
 
 
     - name: Setup pip cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: pip-3.9-${{ hashFiles('package.json') }}
@@ -35,7 +35,7 @@ jobs:
       id: yarn-cache-dir-path
       run: echo "::set-output name=dir::$(yarn cache dir)"
     - name: Setup yarn cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
       with:
         path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
@@ -102,7 +102,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - uses: actions/download-artifact@v4
       with:
         name: myextension-sdist


### PR DESCRIPTION
## Summary
- Update deprecated GitHub Actions that cause CI failures
- `actions/checkout` v2 → v4 (build.yml, release.yml)
- `actions/setup-python` v2 → v5 (build.yml, release.yml)
- `actions/setup-node` v3 → v4 (release.yml)
- `actions/cache` v2 → v4 (release.yml)
- `actions/github-script` v3 → v7 (binder-on-pr.yml)